### PR TITLE
Yf add psi se

### DIFF
--- a/leafcutter/DESCRIPTION
+++ b/leafcutter/DESCRIPTION
@@ -2,7 +2,7 @@ Package: leafcutter
 Type: Package
 Title: Alternative splicing quantification, differential splicing, 
     outlier splicing detection, and splicing QTL mapping
-Version: 0.2.9
+Version: 0.2.9.4
 Date: 2020-04-15
 Authors@R: c(person("David", "Knowles", email = "dak2173@columbia.edu", role = c("aut", "cre")),
               person("Yang", "Li", role = c("aut", "cre")),
@@ -51,7 +51,8 @@ LinkingTo:
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 Suggests: knitr,
-    rmarkdown
+    rmarkdown,
+    stringi
 VignetteBuilder: knitr
 NeedsCompilation: yes
 SystemRequirements: GNU make

--- a/leafcutter/R/differential_splicing.R
+++ b/leafcutter/R/differential_splicing.R
@@ -33,18 +33,29 @@ beta_real=function(r)
 leaf_cutter_effect_sizes=function(results) {
   normalize=function(g) { g/sum(g) }
   softmax=function(g) normalize(exp(g))
-  to_psi=function(b,conc) { normalize(softmax(b)*conc) }
+  to_a=function(b,conc) { softmax(b)*conc }
+  to_psi=function(b,conc) { normalize(to_a(b,conc)) }
+  a_to_se=function(a){ # standard error vector of a Dirichlet distribution with parameters a
+    a_tilde=normalize(a)
+    sqrt(a_tilde*(1-a_tilde)/(sum(a)+1)) 
+  }
   foreach(res=results, .combine = bind_rows) %do% {
     if ( is.character(res) | ("error" %in% class(res)) ) NULL else {
        beta=beta_real( res$fit_full$par )
        data.frame( intron=colnames(beta),
                    logef=beta[2,],
-                   baseline=to_psi(beta[1,],res$fit_full$par$conc),
-                   perturbed=to_psi(beta[1,]+beta[2,],res$fit_full$par$conc),
-                   stringsAsFactors = F )
+                   baseline_a=to_a(beta[1,],res$fit_full$par$conc),
+                   perturbed_a=to_a(beta[1,]+beta[2,],res$fit_full$par$conc), 
+                   stringsAsFactors = F ) %>% 
+      mutate(baseline=normalize(baseline_a),
+             perturbed=normalize(perturbed_a),
+             baseline_psi_se=a_to_se(baseline_a),
+             perturbed_psi_se=a_to_se(perturbed_a)
+             )
     }
   } %>%
-  mutate( deltapsi=perturbed-baseline)
+  mutate( deltapsi=perturbed-baseline) %>%
+  select(intron,logef,baseline,perturbed, deltapsi, everything())
 }
 
 

--- a/leafcutter/R/differential_splicing.R
+++ b/leafcutter/R/differential_splicing.R
@@ -49,13 +49,13 @@ leaf_cutter_effect_sizes=function(results) {
                    stringsAsFactors = F ) %>% 
       mutate(baseline=normalize(baseline_a),
              perturbed=normalize(perturbed_a),
-             baseline_psi_se=a_to_se(baseline_a),
-             perturbed_psi_se=a_to_se(perturbed_a)
+             baseline_se=a_to_se(baseline_a),
+             perturbed_se=a_to_se(perturbed_a)
              )
     }
   } %>%
   mutate( deltapsi=perturbed-baseline) %>%
-  select(intron,logef,baseline,perturbed, deltapsi, everything())
+  select(intron, logef, baseline, perturbed, deltapsi, baseline_se, perturbed_se)
 }
 
 

--- a/leafcutter/vignettes/Installation.Rmd
+++ b/leafcutter/vignettes/Installation.Rmd
@@ -2,7 +2,7 @@
 title: "Installation"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Installation}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/leafcutter/vignettes/Usage.Rmd
+++ b/leafcutter/vignettes/Usage.Rmd
@@ -2,7 +2,7 @@
 title: "Differential Splicing"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Differential Splicing}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/leafcutter/vignettes/UsageLeafcutterMD.Rmd
+++ b/leafcutter/vignettes/UsageLeafcutterMD.Rmd
@@ -2,7 +2,7 @@
 title: "Outlier Splicing"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Outlier Splicing}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/leafcutter/vignettes/Visualization.Rmd
+++ b/leafcutter/vignettes/Visualization.Rmd
@@ -2,7 +2,7 @@
 title: "Leafcutter Shiny App"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Leafcutter Shiny App}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/leafcutter/vignettes/sQTL.Rmd
+++ b/leafcutter/vignettes/sQTL.Rmd
@@ -2,7 +2,7 @@
 title: "Splicing QTL"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Splicing QTL}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This adds two columns to the effect_sizes output: baseline_se & perturbed_se, namely the standard error of the perturbed and baseline psi values as predicted by the fitted Dirichlet distribution. 

- Add standard errors 
- Fix name of vignettes
- Bump version
- Use stringi::stri_replace_all_regex to change the column names