### PR TITLE
Protect list access from sample names that look like numbers

### DIFF
--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -408,7 +408,7 @@ all.clusters$N  <- results$N[ match( all.clusters$clusterID, results$clusterID)]
 all.clusters$verdict <- unlist(classification.list)[ match(all.clusters$clusterID, names(classification.list))]
 
 # prepare for PCA
-counts <- counts[,meta$sample]
+counts <- counts[,as.character(meta$sample)]
 print( "converting counts to ratios")
 # create per cluster ratios from counts
 ratios <- counts %>%

--- a/scripts/leafcutter_ds.R
+++ b/scripts/leafcutter_ds.R
@@ -28,7 +28,7 @@ if (!file.exists(groups_file)) stop("File ",groups_file," does not exist")
 meta=read.table(groups_file, header=F, stringsAsFactors = F)
 colnames(meta)[1:2]=c("sample","group")
 
-counts=counts[,meta$sample]
+counts=counts[,as.character(meta$sample)]
 
 group_names=unique(meta$group) # keep order from groups_file unless numeric
 if (is.numeric(meta$group)) group_names=sort(group_names)


### PR DESCRIPTION
R's casts strings to ints when it can, and then using the int's to access a list....

When a sample is "10" or something like that it can go horribly wrong. 

This PR protects against the behavior by wrapping the sample.ids with `as.character` where appropriate