### PR TITLE
Bugfix to `prepare_results.R`

### DIFF
--- a/clustering/leafcutter_cluster_regtools.py
+++ b/clustering/leafcutter_cluster_regtools.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # https://github.com/griffithlab/regtools
 # /home/yangili1/tools/regtools/build/regtools junctions extract -a 8 -i 50 -I 500000 bamfile.bam -o outfile.junc
 # Using regtools speeds up the junction extraction step by an order of magnitude or more

--- a/clustering/leafcutter_cluster_regtools.py
+++ b/clustering/leafcutter_cluster_regtools.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # https://github.com/griffithlab/regtools
 # /home/yangili1/tools/regtools/build/regtools junctions extract -a 8 -i 50 -I 500000 bamfile.bam -o outfile.junc
 # Using regtools speeds up the junction extraction step by an order of magnitude or more

--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -198,7 +198,7 @@ for( clu in clusters ){
   cluster_ensemblIDs <- names(sort(table( c(tprime$gene_id,fprime$gene_id)), decreasing = TRUE ))
   cluster_ensemblID <- cluster_ensemblIDs[ cluster_ensemblIDs != "." ][1]
   if( length( cluster_ensemblID ) == 0 ){
-    cluster_ensemblID == "."
+    cluster_ensemblID <- "."
   }
 
   verdict <- c()


### PR DESCRIPTION
Failing to set `cluster_ensemblID <- "."` makes ensembleID and gene name columns mismatched in output Rdata object. This PR pulls in the fix from the `davidaknowles/leafcutter` `master` branch.
